### PR TITLE
Update `ActiveRecord::Associations::Preloader` arity

### DIFF
--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -114,7 +114,9 @@ module Tolk
       phrases = phrases.where('tolk_phrases.id NOT IN (?)', existing_ids) if existing_ids.present?
 
       result = phrases.public_send(pagination_method, page)
-      if Rails.version =~ /^4\.0/
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('7')
+        ActiveRecord::Associations::Preloader.new(records: result, associations: :translations).call
+      elsif Rails.version =~ /^4\.0/
         ActiveRecord::Associations::Preloader.new result, :translations
       else
         ActiveRecord::Associations::Preloader.new().preload(result, :translations)
@@ -150,7 +152,9 @@ module Tolk
 #      phrases = phrases.scoped(:conditions => ['tolk_phrases.id NOT IN (?) AND tolk_phrases.id IN(?)', existing_ids, found_translations_ids]) if existing_ids.present?
       phrases = phrases.where(['tolk_phrases.id NOT IN (?) AND tolk_phrases.id IN(?)', existing_ids, found_translations_ids]) if existing_ids.present?
       result = phrases.public_send(pagination_method, page)
-      if Rails.version =~ /^4\.0/
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('7')
+        ActiveRecord::Associations::Preloader.new(records: result, associations: :translations).call
+      elsif Rails.version =~ /^4\.0/
         ActiveRecord::Associations::Preloader.new result, :translations
       else
         ActiveRecord::Associations::Preloader.new().preload(result, :translations)
@@ -193,7 +197,9 @@ module Tolk
     def translations_with_html
       translations = self.translations.all(:conditions => "tolk_translations.text LIKE '%>%' AND
         tolk_translations.text LIKE '%<%' AND tolk_phrases.key NOT LIKE '%_html'", :joins => :phrase)
-      if Rails.version =~ /^4\.0/
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('7')
+        ActiveRecord::Associations::Preloader.new(records: translations, associations: :phrase).call
+      elsif Rails.version =~ /^4\.0/
         ActiveRecord::Associations::Preloader.new translations, :phrase
       else
         ActiveRecord::Associations::Preloader.new().preload(translations, :phrase)
@@ -239,7 +245,9 @@ module Tolk
         phrase.translation = phrase.translations.for(self)
       end
 
-      if Rails.version =~ /^4\.0/
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('7')
+        ActiveRecord::Associations::Preloader.new(records: result, associations: :translations).call
+      elsif Rails.version =~ /^4\.0/
         ActiveRecord::Associations::Preloader.new result, :translations
       else
         ActiveRecord::Associations::Preloader.new().preload(result, :translations)


### PR DESCRIPTION
Rails 7 rightfully change this private API signature, so we need to update it